### PR TITLE
feat: Expose lr_decay paras for flexible conf

### DIFF
--- a/bert_benchmark/run_pretraining.py
+++ b/bert_benchmark/run_pretraining.py
@@ -101,6 +101,10 @@ parser.add_argument("--attention_probs_dropout_prob", type=float, default=0.1)
 parser.add_argument("--hidden_dropout_prob", type=float, default=0.1)
 parser.add_argument("--hidden_size_per_head", type=int, default=64)
 
+parser.add_argument("--lr_decay_num", type=int, default= 100000)
+parser.add_argument("--lr_decay_num_same_as_iter_num",
+        default=False, type=(lambda x: str(x).lower() == 'true'))
+
 args = parser.parse_args()
 
 
@@ -193,7 +197,9 @@ def BuildPreTrainNet(
 
 _BERT_MODEL_UPDATE_CONF = dict(
     learning_rate_decay=dict(
-        polynomial_conf=dict(decay_batches=100000, end_learning_rate=0.0,)
+        polynomial_conf=dict(
+            decay_batches=args.iter_num if args.lr_decay_num_same_as_iter_num else args.lr_decay_num, 
+            end_learning_rate=0.0,)
     ),
     warmup_conf=dict(linear_conf=dict(warmup_batches=1000, start_multiplier=0,)),
     clip_conf=dict(clip_by_global_norm=dict(clip_norm=1.0,)),


### PR DESCRIPTION
共暴露两个参数出来，分别是`lr_decay_num`和`lr_decay_num_same_as_iter_num`
TF的lr_decay_num默认和iter_num相同，但OF debug时有需求需要固定lr_decay_num，所以共暴露两个接口出来