### PR TITLE
fix: Fix the wrong use of enable_auto_mixed_precision

### DIFF
--- a/bert_benchmark/run_pretraining.py
+++ b/bert_benchmark/run_pretraining.py
@@ -41,7 +41,8 @@ parser.add_argument("--data_dir", type=str, default=None)
 parser.add_argument(
     "--data_part_num", type=int, default=32, help="data part number in dataset"
 )
-parser.add_argument("--enable_auto_mixed_precision", type=bool, default=False)
+parser.add_argument("--enable_auto_mixed_precision", default=False,
+        type=lambda x: (str(x).lower() == 'true'))
 
 # log and resore/save
 parser.add_argument(


### PR DESCRIPTION
argparse对bool类型的参数支持有问题，使得即使配置`--enable_auto_mixed_precision=False`，其真正解析出来的值仍然是`True`

解决方法见：https://stackoverflow.com/a/46951029