### PR TITLE
enable_fuse_add_to_output

### DIFF
--- a/Classification/cnns/job_function_util.py
+++ b/Classification/cnns/job_function_util.py
@@ -25,13 +25,13 @@ def _default_config(args):
         config.enable_auto_mixed_precision(True)
     if args.use_xla:
         config.use_xla_jit(True)
+    config.enable_fuse_add_to_output(True)
     return config
 
 
 def get_train_config(args):
     train_config = _default_config(args)
     train_config.cudnn_conv_heuristic_search_algo(False)
-
 
     train_config.prune_parallel_cast_ops(True)
     train_config.enable_inplace(True)


### PR DESCRIPTION
Tested on Tesla V100-SXM2 16G(leinao VS003)
float32
batch size = 128
1 node 1 device

Test result:
- enable_fuse_add_to_output=OFF: throughput 387.5543
- enable_fuse_add_to_output=ON: throughput 397.2944






