### PR TITLE
change default value of fuse_bn_relu and fuse_bn_add_relu to false te…

### DIFF
--- a/Classification/cnns/config.py
+++ b/Classification/cnns/config.py
@@ -90,13 +90,13 @@ def get_parser(parser=None):
     parser.add_argument(
         '--fuse_bn_relu',
         type=str2bool,
-        default=True,
+        default=False,
         help='Whether to use use fuse batch normalization relu'
     )
     parser.add_argument(
         '--fuse_bn_add_relu',
         type=str2bool,
-        default=True,
+        default=False,
         help='Whether to use use fuse batch normalization add relu'
     )
 

--- a/Classification/cnns/config.py
+++ b/Classification/cnns/config.py
@@ -91,13 +91,13 @@ def get_parser(parser=None):
         '--fuse_bn_relu',
         type=str2bool,
         default=False,
-        help='Whether to use use fuse batch normalization relu'
+        help='Whether to use use fuse batch normalization relu. Currently supported in origin/master of OneFlow only.'
     )
     parser.add_argument(
         '--fuse_bn_add_relu',
         type=str2bool,
         default=False,
-        help='Whether to use use fuse batch normalization add relu'
+        help='Whether to use use fuse batch normalization add relu. Currently supported in origin/master of OneFlow only.'
     )
 
     # inference


### PR DESCRIPTION
Change default value of `fuse_bn_relu` and `fuse_bn_add_relu` to `false` temporary.
Hold for new release of OneFlow with `fuse bn` feature.