### PR TITLE
Optimize bert attention mask calculation

### DIFF
--- a/LanguageModeling/BERT/bert.py
+++ b/LanguageModeling/BERT/bert.py
@@ -61,9 +61,11 @@ class BertBackbone(object):
       with flow.scope.namespace("encoder"):
         attention_mask_blob = _CreateAttentionMaskFromInputMask(
           input_mask_blob, from_seq_length=seq_length, to_seq_length=seq_length)
+        addr_blob = _CreateAddrFromAttentionMask(
+          attention_mask_blob, from_seq_length=seq_length, to_seq_length=seq_length)
         self.all_encoder_layers_ = _TransformerModel(
             input_blob=self.embedding_output_,
-            attention_mask_blob=attention_mask_blob,
+            addr_blob=addr_blob,
             seq_length=seq_length,
             hidden_size=hidden_size,
             num_hidden_layers=num_hidden_layers,
@@ -88,7 +90,7 @@ def _Gelu(in_blob):
   return flow.math.gelu(in_blob)
 
 def _TransformerModel(input_blob,
-                      attention_mask_blob,
+                      addr_blob,
                       seq_length,
                       hidden_size=768,
                       num_hidden_layers=12,
@@ -113,7 +115,7 @@ def _TransformerModel(input_blob,
           attention_output_blob = _AttentionLayer(
               from_blob=layer_input_blob,
               to_blob=layer_input_blob,
-              attention_mask_blob=attention_mask_blob,
+              addr_blob=addr_blob,
               num_attention_heads=num_attention_heads,
               size_per_head=attention_head_size,
               attention_probs_dropout_prob=attention_probs_dropout_prob,
@@ -171,7 +173,7 @@ def _TransformerModel(input_blob,
 
 def _AttentionLayer(from_blob,
                     to_blob,
-                    attention_mask_blob,
+                    addr_blob,
                     num_attention_heads=1,
                     size_per_head=512,
                     query_act=op_conf_util.kNone,
@@ -222,7 +224,7 @@ def _AttentionLayer(from_blob,
   attention_scores_blob = flow.matmul(query_blob, key_blob, transpose_b=True)
   attention_scores_blob = attention_scores_blob * (1.0 / math.sqrt(float(size_per_head)))
 
-  attention_scores_blob = attention_scores_blob + attention_mask_blob
+  attention_scores_blob = attention_scores_blob + addr_blob
   attention_probs_blob = flow.nn.softmax(attention_scores_blob)
   attention_probs_blob = _Dropout(attention_probs_blob, attention_probs_dropout_prob)
 
@@ -267,7 +269,11 @@ def _CreateAttentionMaskFromInputMask(to_mask_blob, from_seq_length, to_seq_leng
   output = flow.cast(to_mask_blob, dtype=flow.float)
   output = flow.reshape(output, [-1, 1, to_seq_length])
   zeros = flow.constant(0.0, dtype=flow.float, shape=[from_seq_length, to_seq_length])
-  attention_mask_blob = zeros + output
+  output = zeros + output
+  return output
+
+
+def _CreateAddrFromAttentionMask(attention_mask_blob, from_seq_length, to_seq_length):
   attention_mask_blob = flow.reshape(attention_mask_blob, [-1, 1, from_seq_length, to_seq_length])
   attention_mask_blob = flow.cast(attention_mask_blob, dtype=flow.float)
   attention_mask_blob = (attention_mask_blob - 1.0) * 10000.0

--- a/LanguageModeling/BERT/bert.py
+++ b/LanguageModeling/BERT/bert.py
@@ -276,8 +276,8 @@ def _CreateAttentionMaskFromInputMask(to_mask_blob, from_seq_length, to_seq_leng
 def _CreateAddrFromAttentionMask(attention_mask_blob, from_seq_length, to_seq_length):
   attention_mask_blob = flow.reshape(attention_mask_blob, [-1, 1, from_seq_length, to_seq_length])
   attention_mask_blob = flow.cast(attention_mask_blob, dtype=flow.float)
-  attention_mask_blob = (attention_mask_blob - 1.0) * 10000.0
-  return attention_mask_blob
+  addr_blob = (attention_mask_blob - 1.0) * 10000.0
+  return addr_blob
 
 
 def _EmbeddingPostprocessor(input_blob,

--- a/LanguageModeling/BERT/pretrain.py
+++ b/LanguageModeling/BERT/pretrain.py
@@ -82,9 +82,6 @@ def PreTrain(
         initializer_range=initializer_range,
     )
     with flow.scope.namespace("cls-loss"):
-        if not use_fp16:
-            lm_loss = flow.math.reduce_mean(lm_loss)
-            ns_loss = flow.math.reduce_mean(ns_loss)
         total_loss = lm_loss + ns_loss
     return total_loss, lm_loss, ns_loss
 

--- a/LanguageModeling/BERT/pretrain.py
+++ b/LanguageModeling/BERT/pretrain.py
@@ -82,6 +82,9 @@ def PreTrain(
         initializer_range=initializer_range,
     )
     with flow.scope.namespace("cls-loss"):
+        if not use_fp16:
+            lm_loss = flow.math.reduce_mean(lm_loss)
+            ns_loss = flow.math.reduce_mean(ns_loss)
         total_loss = lm_loss + ns_loss
     return total_loss, lm_loss, ns_loss
 

--- a/LanguageModeling/BERT/util.py
+++ b/LanguageModeling/BERT/util.py
@@ -129,6 +129,7 @@ class Metric(object):
     def _clear(self):
         for key in self.keys:
             self.metric_dict[key] = 0.0
+            self.metric_dict['n_' + key] = 0.0
         self.metric_dict['throughput'] = 0.0
         self.num_samples = 0.0
 
@@ -143,6 +144,7 @@ class Metric(object):
 
             for key in self.keys:
                 self.metric_dict[key] += outputs[key].sum()
+                self.metric_dict['n_' + key] += outputs[key].size
 
             self.num_samples += self.batch_size
 
@@ -153,7 +155,7 @@ class Metric(object):
                 throughput = self.num_samples / self.timer.split()
                 self.update_and_save('throughput', throughput, step)
                 for key in self.keys:
-                    value = self.metric_dict[key] / self.num_samples
+                    value = self.metric_dict[key] / self.metric_dict['n_' + key]
                     self.update_and_save(key, value, step, **kwargs)
                 print(', '.join(('{}: {}' if type(v) is int else '{}: {:.3f}').format(k, v) \
                                 for k, v in self.metric_dict.items()), time.time())

--- a/LanguageModeling/BERT/util.py
+++ b/LanguageModeling/BERT/util.py
@@ -135,6 +135,7 @@ class Metric(object):
 
     def update_and_save(self, key, value, step, **kwargs):
         self.metric_dict[key] = value
+        self.metric_dict.pop('n_' + key, None)
         if self.save_summary:
             self.summary.scalar(self.desc + "_" + key, step, value, **kwargs)
 


### PR DESCRIPTION
1.  move calculation of `addr` out of layer
2.  fix loss print bug in fp32

regression test result:
![image](https://user-images.githubusercontent.com/16327185/99378380-52c13800-2902-11eb-874f-c9b068b0c99f.png)
