### PR TITLE
fix resnet2onnx bug

### DIFF
--- a/Classification/cnns/resnet2onnx.sh
+++ b/Classification/cnns/resnet2onnx.sh
@@ -1,0 +1,4 @@
+python3 resnet_to_onnx.py \
+     --channel_last=False \
+     --fuse_bn_relu=False \
+     --fuse_bn_add_relu=False

--- a/Classification/cnns/resnet_to_onnx.py
+++ b/Classification/cnns/resnet_to_onnx.py
@@ -27,8 +27,11 @@ import onnx
 import onnxruntime as ort
 
 from resnet_model import resnet50
+import config as configs
 from imagenet1000_clsidx_to_labels import clsidx_2_labels
 
+parser = configs.get_parser()
+args = parser.parse_args()
 
 def load_image(image_path: Text) -> np.ndarray:
     rgb_mean = [123.68, 116.779, 103.939]
@@ -46,7 +49,7 @@ def load_image(image_path: Text) -> np.ndarray:
 
 @flow.global_function("predict")
 def InferenceNet(images: tp.Numpy.Placeholder((1, 3, 224, 224), dtype=flow.float)) -> tp.Numpy:
-    logits = resnet50(images, training=False)
+    logits = resnet50(images, args, training=False)
     predictions = flow.nn.softmax(logits)
     return predictions
 


### PR DESCRIPTION
给resnet2onnx.py增加args参数，并配有shell脚本

由于预训练模型没有做bn relu融合，所以在shell脚本里，相关选项置为False，目前已成功运行正确结果

![图片](https://user-images.githubusercontent.com/42901638/109119241-5f65ef80-777f-11eb-9973-63490ad037c1.png)
